### PR TITLE
Image gallery size fix

### DIFF
--- a/client/src/components/Overview.jsx
+++ b/client/src/components/Overview.jsx
@@ -15,11 +15,13 @@ class Overview extends React.Component {
       currentPointInGallery: 0,
       currentPointInGalleryStart: 0,
       currentPointInGalleryEndNonInclusive: 5,
-      currentGalleryLength: sampleData.productStylesById.results[0].photos.length // length of currentSelectedStyleImages reference
+      currentGalleryLength: sampleData.productStylesById.results[0].photos.length, // length of currentSelectedStyleImages reference
+      currentView: 'regular'
     }
     this.galleryScrollClick = this.galleryScrollClick.bind(this);
-    this.nextAndPrevious = this.nextAndPrevious.bind(this);
     this.galleryImageClick = this.galleryImageClick.bind(this);
+    this.nextAndPrevious = this.nextAndPrevious.bind(this);
+    this.viewSwitchClick = this.viewSwitchClick.bind(this);
   }
 
   galleryScrollClick(e) {
@@ -73,10 +75,14 @@ class Overview extends React.Component {
     });
   }
 
+  viewSwitchClick(e, option) {
+    console.log('I have been clicked');
+  }
+
   render() {
     return (
       <div className={layoutStyles.overviewLayout}>
-        <OverviewImgGal className={layoutStyles.imageGalleryComp} currentImg={this.state.currentImg} currentSelectedStyleImages={this.state.currentSelectedStyleImages} galleryScrollClick={this.galleryScrollClick} currentPointInGalleryStart={this.state.currentPointInGalleryStart} currentPointInGalleryEndNonInclusive={this.state.currentPointInGalleryEndNonInclusive} currentGalleryLength={this.state.currentGalleryLength} nextAndPrevious={this.nextAndPrevious} currentPointInGallery={this.state.currentPointInGallery} galleryImageClick={this.galleryImageClick} />
+        <OverviewImgGal className={layoutStyles.imageGalleryComp} currentImg={this.state.currentImg} currentSelectedStyleImages={this.state.currentSelectedStyleImages} galleryScrollClick={this.galleryScrollClick} currentPointInGalleryStart={this.state.currentPointInGalleryStart} currentPointInGalleryEndNonInclusive={this.state.currentPointInGalleryEndNonInclusive} currentGalleryLength={this.state.currentGalleryLength} nextAndPrevious={this.nextAndPrevious} currentPointInGallery={this.state.currentPointInGallery} galleryImageClick={this.galleryImageClick} viewSwitchClick={this.viewSwitchClick} />
         <div className={layoutStyles.infoStyleCart}>
           <div className={layoutStyles.productInfoComp}>CSS Placement: Product Info</div>
           <div className={layoutStyles.styleSelectorComp}>CSS Placement: Style Select</div>

--- a/client/src/components/Overview.jsx
+++ b/client/src/components/Overview.jsx
@@ -76,7 +76,10 @@ class Overview extends React.Component {
   }
 
   viewSwitchClick(e, option) {
-    console.log('I have been clicked');
+    // console.log('I have been clicked');
+    // console.log(e.target.innerHTML);
+    // e.target.innerHTML = 'Regular?';
+
   }
 
   render() {

--- a/client/src/components/OverviewComponents/OverviewImgGal.jsx
+++ b/client/src/components/OverviewComponents/OverviewImgGal.jsx
@@ -31,7 +31,7 @@ const OverviewImgGal = (props) => {
         <button onClick={(e) => props.nextAndPrevious(e, 'next')}>Next?</button>
       </div>
       <div className={styles.view}>
-        <button>Full?</button>
+        <button onClick={(e) => props.viewSwitchClick(e)}>Full?</button>
       </div>
     </div>
   );

--- a/client/src/components/OverviewComponents/OverviewImgGal.jsx
+++ b/client/src/components/OverviewComponents/OverviewImgGal.jsx
@@ -5,14 +5,12 @@ const OverviewImgGal = (props) => {
   let renderMoreButton = (length) => {
     if (length > 4) {
       return (
-        <button style={{'marginTop': '2%'}} onClick={(e) => props.galleryScrollClick(e)}>Click for<br></br>more!</button>
+        <button onClick={(e) => props.galleryScrollClick(e)}>Click for<br></br>more!</button>
       );
     }
   };
   let selectedStyle = {
     'borderBottom': 'solid black',
-    'marginBottom': '2%',
-    'paddingBottom': '1%'
   }
   let notSelectedStyle = {
     'borderBottom': 'none'
@@ -32,7 +30,9 @@ const OverviewImgGal = (props) => {
         <button onClick={(e) => props.nextAndPrevious(e, 'previous')}>Prev?</button>
         <button onClick={(e) => props.nextAndPrevious(e, 'next')}>Next?</button>
       </div>
-      <div className={styles.view}>CSS Placement: View Change</div>
+      <div className={styles.view}>
+        <button>Full?</button>
+      </div>
     </div>
   );
 };

--- a/client/src/components/OverviewComponents/OverviewImgGal.jsx
+++ b/client/src/components/OverviewComponents/OverviewImgGal.jsx
@@ -5,7 +5,7 @@ const OverviewImgGal = (props) => {
   let renderMoreButton = (length) => {
     if (length > 4) {
       return (
-        <button onClick={(e) => props.galleryScrollClick(e)}>Click for<br></br>more!</button>
+        <button style={{'marginTop': '2%'}} onClick={(e) => props.galleryScrollClick(e)}>Click for<br></br>more!</button>
       );
     }
   };
@@ -29,10 +29,10 @@ const OverviewImgGal = (props) => {
       </div>
       <img src={props.currentImg} className={styles.image}></img>
       <div className={styles.switchImage}>
-        <button onClick={(e) => props.nextAndPrevious(e, 'previous')}>Previous?</button>
-        <button style={{'marginLeft': '80%'}} onClick={(e) => props.nextAndPrevious(e, 'next')}>Next?</button>
+        <button onClick={(e) => props.nextAndPrevious(e, 'previous')}>Prev?</button>
+        <button onClick={(e) => props.nextAndPrevious(e, 'next')}>Next?</button>
       </div>
-      <div className={styles.view}>CSS Placement: View Change (Coming Back to this Later)</div>
+      <div className={styles.view}>CSS Placement: View Change</div>
     </div>
   );
 };

--- a/client/src/css-modules/overview-image-gallery.module.css
+++ b/client/src/css-modules/overview-image-gallery.module.css
@@ -8,6 +8,8 @@
   max-width: 800px;
   min-height: 600px;
   max-height: 600px;
+  background-color: grey;
+  margin: 1%;
 }
 .gallery {
   grid-area: 1 / 1 / 5 / 2;
@@ -25,11 +27,13 @@
   grid-area: 3 / 2 / 4 / 5;
   display: flex;
   justify-content: space-between;
+  padding: 1.5%;
 }
 .view {
   grid-area: 1 / 4 / 2 / 5;
   text-align: right;
-  padding-top: 6%;
+  padding: 6%;
+
 }
 .thumbnail {
   display: block;

--- a/client/src/css-modules/overview-image-gallery.module.css
+++ b/client/src/css-modules/overview-image-gallery.module.css
@@ -1,9 +1,3 @@
-.thumbnail {
-  display: block;
-  width: 40%;
-  height: auto;
-  padding-top: 2%;
-}
 
 .imageGallery {
   display: grid;
@@ -15,7 +9,10 @@
   min-height: 600px;
   max-height: 600px;
 }
-.gallery { grid-area: 1 / 1 / 5 / 2; }
+.gallery {
+  grid-area: 1 / 1 / 5 / 2;
+  margin: 2%
+}
 .image {
   display: block;
   grid-area: 1 / 3 / 5 / 4;
@@ -29,4 +26,15 @@
   display: flex;
   justify-content: space-between;
 }
-.view { grid-area: 1 / 4 / 2 / 5; }
+.view {
+  grid-area: 1 / 4 / 2 / 5;
+  text-align: right;
+  padding-top: 6%;
+}
+.thumbnail {
+  display: block;
+  width: 40%;
+  height: auto;
+  padding-bottom: 2%;
+  margin-bottom: 2%;
+}

--- a/client/src/css-modules/overview-image-gallery.module.css
+++ b/client/src/css-modules/overview-image-gallery.module.css
@@ -1,20 +1,32 @@
 .thumbnail {
   display: block;
-  width: 20%;
+  width: 40%;
   height: auto;
+  padding-top: 2%;
 }
+
 .imageGallery {
   display: grid;
-  grid-template-columns: 1fr 0.5fr 2fr 0.5fr;
+  grid-template-columns: 1fr 0.6fr 1.8fr 0.6fr;
   grid-template-rows: 0.5fr 1.5fr 0.5fr 1.5fr;
   gap: 0px 0px;
+  min-width: 800px;
+  max-width: 800px;
+  min-height: 600px;
+  max-height: 600px;
 }
 .gallery { grid-area: 1 / 1 / 5 / 2; }
 .image {
+  display: block;
   grid-area: 1 / 3 / 5 / 4;
-  width: 50%;
+  max-width: 100%;
   height: auto;
+  text-align: center;
+  margin: auto;
 }
-.switchImage { grid-area: 3 / 2 / 4 / 5; }
+.switchImage {
+  grid-area: 3 / 2 / 4 / 5;
+  display: flex;
+  justify-content: space-between;
+}
 .view { grid-area: 1 / 4 / 2 / 5; }
-

--- a/client/src/css-modules/overview-layout.module.css
+++ b/client/src/css-modules/overview-layout.module.css
@@ -19,7 +19,7 @@
     "styleSelectorComp"
     "cartComp";
   grid-area: infoStyleCart;
-  margin: 2%;
+  padding: 3%;
 }
 .productInfoComp { grid-area: productInfoComp; }
 .styleSelectorComp { grid-area: styleSelectorComp; }

--- a/client/src/css-modules/overview-layout.module.css
+++ b/client/src/css-modules/overview-layout.module.css
@@ -1,7 +1,7 @@
 .overviewLayout {
   display: grid;
-  grid-template-columns: 1.4fr 0.6fr;
-  grid-template-rows: 1fr 0.5fr;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 0.2fr;
   gap: 0px 0px;
   grid-template-areas:
     "imageGalleryComp infoStyleCart"
@@ -11,7 +11,7 @@
 .productDescriptionComp { grid-area: productDescriptionComp; }
 .infoStyleCart {
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: 2fr;
   grid-template-rows: 1fr 1fr 1fr;
   gap: 0px 0px;
   grid-template-areas:

--- a/client/src/css-modules/overview-layout.module.css
+++ b/client/src/css-modules/overview-layout.module.css
@@ -19,6 +19,7 @@
     "styleSelectorComp"
     "cartComp";
   grid-area: infoStyleCart;
+  margin: 2%;
 }
 .productInfoComp { grid-area: productInfoComp; }
 .styleSelectorComp { grid-area: styleSelectorComp; }


### PR DESCRIPTION
## Description ##
https://trello.com/c/HtYe8hW8

This should take care of the next and previous buttons staying in one location and not flailing all over, and will now make the full size image in regular view render centered both horizontally and vertically.

## Type of change ##
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Part of a feature.
- [ ] Refactor (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
## Checklist ##
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] added new dependencies
- [ ] added tests
- [ ] updated documentation
- [x] Looks good on large screens
- [x] Looks good on mobile
## Organization ##
- [x] Have you linked this pull request to a Trello card?
## Review ##
- [ ] Is this a work in progress?
- [x] Is this ready to be reviewed?
- [x] Have you added at least one reviewer to this pull request?