### PR TITLE
Ov prod info loose ends

### DIFF
--- a/client/dist/index.html
+++ b/client/dist/index.html
@@ -6,6 +6,10 @@
     src="https://kit.fontawesome.com/b0189b6962.js"
     crossorigin="anonymous">
   </script>
+  <!-- Twitter Button script -->
+  <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+  <!-- Pinterest Button script -->
+  <script async defer src="//assets.pinterest.com/js/pinit.js"></script>
   <link rel="stylesheet" type="text/css" href="css/style.css">
 </head>
 <body>

--- a/client/src/components/Overview.jsx
+++ b/client/src/components/Overview.jsx
@@ -34,6 +34,7 @@ class Overview extends React.Component {
       infoData: sampleData.productById,
       stars: getStarRatings(getAverageRatings(sampleData.reviewMetaData.ratings)),
       actualPrice: sampleData.productStylesById.results[0].sale_price ? sampleData.productStylesById.results[0].sale_price : sampleData.productStylesById.results[0].original_price,
+      amountOfReviews: sampleData.reviewList.count,
     };
     ////// image gallery functionality //////
     this.galleryScrollClick = this.galleryScrollClick.bind(this);
@@ -157,6 +158,7 @@ class Overview extends React.Component {
               infoData={this.state.infoData}
               stars={this.state.stars}
               actualPrice={this.state.actualPrice}
+              amountOfReviews={this.state.amountOfReviews}
             />
             <OverviewStyleSelect
               className={layoutStyles.styleSelectorComp}

--- a/client/src/components/OverviewComponents/OverviewProductInfo.jsx
+++ b/client/src/components/OverviewComponents/OverviewProductInfo.jsx
@@ -53,9 +53,9 @@ const OverviewProductInfo = (props) => {
         {' <-- Not on wireframe, although it is in biz docs'}
       </div>
       <div className={styles.share}>
-        <button className={styles.shareButton}>Facebook</button>
-        <button className={styles.shareButton}>Twitter</button>
-        <button className={styles.shareButton}>Pinterest</button>
+        <iframe title="share" src="https://www.facebook.com/plugins/share_button.php?href=http%3A%2F%2F127.0.0.1%3A3000%2F&layout=button&size=small&width=67&height=20&appId" width="67" height="20" style={{ border: 'none', overflow: 'hidden' }} scrolling="no" frameBorder="0" allowFullScreen={true} allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share" />
+        <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" className="twitter-share-button" data-show-count="false">Tweet</a>
+        <a data-pin-do="buttonBookmark" data-pin-lang="en" href="https://www.pinterest.com/pin/create/button/" style={{ padding: '5%' }}>Save</a>
         {' <-- Implement Share Functionality.'}
       </div>
     </div>

--- a/client/src/components/OverviewComponents/OverviewProductInfo.jsx
+++ b/client/src/components/OverviewComponents/OverviewProductInfo.jsx
@@ -56,7 +56,6 @@ const OverviewProductInfo = (props) => {
         <iframe title="share" src="https://www.facebook.com/plugins/share_button.php?href=http%3A%2F%2F127.0.0.1%3A3000%2F&layout=button&size=small&width=67&height=20&appId" width="67" height="20" style={{ border: 'none', overflow: 'hidden' }} scrolling="no" frameBorder="0" allowFullScreen={true} allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share" />
         <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" className="twitter-share-button" data-show-count="false">Tweet</a>
         <a data-pin-do="buttonBookmark" data-pin-lang="en" href="https://www.pinterest.com/pin/create/button/" style={{ padding: '5%' }}>Save</a>
-        {' <-- Implement Share Functionality.'}
       </div>
     </div>
   );

--- a/client/src/components/OverviewComponents/OverviewProductInfo.jsx
+++ b/client/src/components/OverviewComponents/OverviewProductInfo.jsx
@@ -32,12 +32,13 @@ const OverviewProductInfo = (props) => {
       return (
         <div className={styles.rating}>
           {stars.map((star, index) => <span key={index}>{star}</span>)}
-          {/* <a href="#ratings-reviews">{`Read all ${amountOfReviews} reviews`}</a> */}
-          <a href="#ratings-reviews" onClick={(e) => smoothScrollClick(e)}>{`Read all ${amountOfReviews} reviews`}</a>
+          {/* {stars.map((star, index) => <div key={index}>{star}</div>)} */}
+          <a style={{ marginTop: '0.25%' }} href="#ratings-reviews" onClick={(e) => smoothScrollClick(e)}>{`Read all ${amountOfReviews} reviews`}</a>
         </div>
       );
     }
     return <div>[No reviews for this product]</div>;
+    // placeholder for now to visualize truthiness of no reviews
   };
 
   return (

--- a/client/src/components/OverviewComponents/OverviewProductInfo.jsx
+++ b/client/src/components/OverviewComponents/OverviewProductInfo.jsx
@@ -9,7 +9,7 @@ const OverviewProductInfo = (props) => {
       return (
         <div className={styles.price}>
           <div style={{ textDecoration: 'line-through' }}>{`$${infoData.default_price}`}</div>
-          <div>{`$${actualPrice}`}</div>
+          <div style={{ color: 'red' }}>{`$${actualPrice}`}</div>
         </div>
       );
     }
@@ -21,11 +21,17 @@ const OverviewProductInfo = (props) => {
       <div className={styles.rating}>
         {stars.map((star, index) => <span key={index}>{star}</span>)}
         <a href="#ratings-reviews">Read all reviews</a>
+        {' <-- Fix to show number of reviews !OR! Fix to not show this section IF no reviews exist'}
       </div>
       <div className={styles.category}>{infoData.category}</div>
       <div className={styles.name}>{infoData.name}</div>
       {defaultOrChange()}
-      <div className={styles.share}>CSS Placement: Share</div>
+      <div className={styles.share}>
+        <button className={styles.shareButton}>Facebook</button>
+        <button className={styles.shareButton}>Twitter</button>
+        <button className={styles.shareButton}>Pinterest</button>
+        {' <-- Implement Share Functionality.'}
+      </div>
     </div>
   );
 };

--- a/client/src/components/OverviewComponents/OverviewProductInfo.jsx
+++ b/client/src/components/OverviewComponents/OverviewProductInfo.jsx
@@ -2,7 +2,12 @@ import React from 'react';
 import styles from '../../css-modules/overview-product-info.module.css';
 
 const OverviewProductInfo = (props) => {
-  const { infoData, stars, actualPrice } = props;
+  const {
+    infoData,
+    stars,
+    actualPrice,
+    amountOfReviews,
+  } = props;
 
   const defaultOrChange = () => {
     if (infoData.default_price !== actualPrice) {
@@ -16,16 +21,36 @@ const OverviewProductInfo = (props) => {
     return <div className={styles.price}>{`$${infoData.default_price}`}</div>;
   };
 
+  const smoothScrollClick = (e) => {
+    e.preventDefault();
+    const rateAndRev = document.getElementById('ratings-reviews');
+    rateAndRev.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
+  const renderReviewsOrNo = () => {
+    if (amountOfReviews) {
+      return (
+        <div className={styles.rating}>
+          {stars.map((star, index) => <span key={index}>{star}</span>)}
+          {/* <a href="#ratings-reviews">{`Read all ${amountOfReviews} reviews`}</a> */}
+          <a href="#ratings-reviews" onClick={(e) => smoothScrollClick(e)}>{`Read all ${amountOfReviews} reviews`}</a>
+        </div>
+      );
+    }
+    return <div>[No reviews for this product]</div>;
+  };
+
   return (
     <div className={styles.productInfoLayout}>
-      <div className={styles.rating}>
-        {stars.map((star, index) => <span key={index}>{star}</span>)}
-        <a href="#ratings-reviews">Read all reviews</a>
-        {' <-- Fix to show number of reviews !OR! Fix to not show this section IF no reviews exist'}
-      </div>
+      {renderReviewsOrNo()}
       <div className={styles.category}>{infoData.category}</div>
       <div className={styles.name}>{infoData.name}</div>
       {defaultOrChange()}
+      <div className={styles.slogan}>
+        {`?Product Overview?: "${infoData.slogan}"`}
+        {/* ^ using the slogan property from productById for this ^ */}
+        {' <-- Not on wireframe, although it is in biz docs'}
+      </div>
       <div className={styles.share}>
         <button className={styles.shareButton}>Facebook</button>
         <button className={styles.shareButton}>Twitter</button>

--- a/client/src/css-modules/overview-product-info.module.css
+++ b/client/src/css-modules/overview-product-info.module.css
@@ -24,7 +24,7 @@
 .category { grid-area: category; }
 .rating {
   grid-area: rating;
-  display: inline;
+  display: inline-flex;
 }
 .slogan { grid-area: slogan; }
 .shareButton { margin: 1% }

--- a/client/src/css-modules/overview-product-info.module.css
+++ b/client/src/css-modules/overview-product-info.module.css
@@ -1,21 +1,24 @@
 .productInfoLayout {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr;
   grid-template-rows: 1fr 0.5fr 1.1fr 0.9fr 0.5fr;
   gap: 0px 0px;
   grid-template-areas:
-    "rating rating"
-    "category category"
-    "name name"
-    "price price"
-    "slogan slogan"
-    "share share";
+    "rating"
+    "category"
+    "name"
+    "price"
+    "slogan"
+    "share";
 }
 .price {
   grid-area: price;
   margin-bottom: 1%
 }
-.share { grid-area: share; }
+.share {
+  grid-area: share;
+  display: inline-flex;
+}
 .name {
   grid-area: name;
   font-size: x-large;

--- a/client/src/css-modules/overview-product-info.module.css
+++ b/client/src/css-modules/overview-product-info.module.css
@@ -1,16 +1,20 @@
 .productInfoLayout {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  grid-template-rows: 1fr 0.5fr 1.5fr 0.5fr 0.5fr;
+  grid-template-rows: 1fr 0.5fr 1.1fr 0.9fr 0.5fr;
   gap: 0px 0px;
   grid-template-areas:
     "rating rating"
     "category category"
     "name name"
     "price price"
+    "slogan slogan"
     "share share";
 }
-.price { grid-area: price; }
+.price {
+  grid-area: price;
+  margin-bottom: 1%
+}
 .share { grid-area: share; }
 .name {
   grid-area: name;
@@ -22,4 +26,5 @@
   grid-area: rating;
   display: inline;
 }
+.slogan { grid-area: slogan; }
 .shareButton { margin: 1% }

--- a/client/src/css-modules/overview-product-info.module.css
+++ b/client/src/css-modules/overview-product-info.module.css
@@ -18,6 +18,7 @@
 .share {
   grid-area: share;
   display: inline-flex;
+  padding-bottom: 1%;
 }
 .name {
   grid-area: name;
@@ -30,4 +31,3 @@
   display: inline-flex;
 }
 .slogan { grid-area: slogan; }
-.shareButton { margin: 1% }

--- a/client/src/css-modules/overview-product-info.module.css
+++ b/client/src/css-modules/overview-product-info.module.css
@@ -1,13 +1,14 @@
 .productInfoLayout {
   display: grid;
-  grid-template-columns: 0.7fr 1.3fr;
-  grid-template-rows: 1fr 0.5fr 1.5fr 1fr;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 0.5fr 1.5fr 0.5fr 0.5fr;
   gap: 0px 0px;
   grid-template-areas:
     "rating rating"
     "category category"
     "name name"
-    "price share";
+    "price price"
+    "share share";
 }
 .price { grid-area: price; }
 .share { grid-area: share; }
@@ -21,3 +22,4 @@
   grid-area: rating;
   display: inline;
 }
+.shareButton { margin: 1% }

--- a/client/src/css-modules/overview-style-select.module.css
+++ b/client/src/css-modules/overview-style-select.module.css
@@ -4,7 +4,7 @@
   grid-template-rows: 1fr 1fr;
   gap: 0px 0px;
   grid-area: thumbnailSelectedLayout;
-  padding: 3%;
+  padding: 4%;
 }
 
 .thumbnailSelected {


### PR DESCRIPTION
## Description ##

Wrapping up product info according to wireframe and biz docs.

Conflict between WireFrame and BizDocs:
	WireFrame does not show a "Product Overview" text block in the Product Information Section of the widget. HOWEVER, BizDocs 1.1.1. Item #5 states otherwise, so I am putting the productById slogan property value in the place of where I believe according to the BizDocs that this should go: below the price.
	Wireframe does not show social media share buttons. However BizDocs 1.1.1. Item #6 states otherwise, so I have added the three requested buttons and put names in their place to show the existance. Functionality is not there.

Product overview item needs to be known, and share buttons need to be made working.

Have one last issue on product info component that will be addressed. I arbitrarily on my own chose the default style. I need to refactor this functionality to detect the productStylesById array item that had a property default with a truthy value.

## Type of change ##
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Part of a feature.
- [x] Refactor (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
## Checklist ##
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] added new dependencies
- [ ] added tests
- [ ] updated documentation
- [x] Looks good on large screens
- [ ] Looks good on mobile
## Organization ##
- [x] Have you linked this pull request to a Trello card?
## Review ##
- [x] Is this a work in progress?
- [x] Is this ready to be reviewed?
- [x] Have you added at least one reviewer to this pull request?